### PR TITLE
fix: wrong module naming

### DIFF
--- a/protoc-gen-gogoslim/go.mod
+++ b/protoc-gen-gogoslim/go.mod
@@ -1,4 +1,4 @@
-module protoc-gen-gogoslim
+module github.com/lqs/gogoslim/protoc-gen-gogoslim
 
 go 1.11
 

--- a/protoc-gen-gogoslim/go.mod
+++ b/protoc-gen-gogoslim/go.mod
@@ -1,4 +1,4 @@
-module github.com/lqs/gogoslim/protoc-gen-gogoslim
+module github.com/leverz/gogoslim/protoc-gen-gogoslim
 
 go 1.11
 

--- a/protoc-gen-gogoslim/go.mod
+++ b/protoc-gen-gogoslim/go.mod
@@ -1,4 +1,4 @@
-module github.com/leverz/gogoslim/protoc-gen-gogoslim
+module github.com/lqs/gogoslim/protoc-gen-gogoslim
 
 go 1.11
 


### PR DESCRIPTION
see [parsing go.mod: unexpected module path](https://github.com/golang/go/wiki/Modules#how-can-i-resolve-parsing-gomod-unexpected-module-path-and-error-loading-module-requirements-errors-caused-by-a-mismatch-between-import-paths-vs-declared-module-identity)